### PR TITLE
Public directory fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,4 +17,6 @@
 
 ---
 
+Forked to resolve root and public directory address being repeated when building the URL as per issue mentioned on [Laracasts forum](https://laracasts.com/discuss/channels/laravel/root-directory-is-displayed-twice-in-url-on-load-and-reload?page=1&replyId=791970).
+
 Visit [inertiajs.com](https://inertiajs.com/) to learn more.

--- a/src/Response.php
+++ b/src/Response.php
@@ -99,7 +99,7 @@ class Response implements Responsable
         $page = [
             'component' => $this->component,
             'props' => $props,
-            'url' => $request->getBaseUrl().$request->getRequestUri(),
+            'url' => $request->getRequestUri(),
             'version' => $this->version,
         ];
 


### PR DESCRIPTION
Modifies URL generation to only use the request URI and not also the base URL.
Fix is as described in this [Laracasts Forum Post](https://laracasts.com/discuss/channels/laravel/root-directory-is-displayed-twice-in-url-on-load-and-reload?page=1&replyId=791970).